### PR TITLE
Do not clear the element, because it no longer exists in the DOM after selecting an item.

### DIFF
--- a/src/macro.php
+++ b/src/macro.php
@@ -39,7 +39,6 @@ Browser::macro('select2', function ($field, $value = null, $wait = 2) {
             $element->sendKeys($item);
             sleep($wait);
             $this->click('.select2-results__option--highlighted');
-            $element->clear();
         }
 
         return $this;


### PR DESCRIPTION
Without this change, I get the following error:
`stale element reference: element is not attached to the page document`

It turns out that after selecting a dropdown item, select2 removes itself from the DOM. So the element can not be cleared. And thus, gives this error.