### PR TITLE
fixes handling grouped options

### DIFF
--- a/src/macro.php
+++ b/src/macro.php
@@ -45,7 +45,7 @@ Browser::macro('select2', function ($field, $value = null, $wait = 2, $suffix = 
     }
 
     // another way - w/o search field.
-    $this->script("jQuery.find(\".select2-results__options .select2-results__option:contains('{$value}')\")[0].click()");
+    $this->script("jQuery.find(\".select2-results__options .select2-results__option[role=treeitem]:contains('{$value}')\")[0].click()");
 
     return $this;
 });

--- a/src/macro.php
+++ b/src/macro.php
@@ -45,7 +45,8 @@ Browser::macro('select2', function ($field, $value = null, $wait = 2, $suffix = 
     }
 
     // another way - w/o search field.
-    $this->script("jQuery.find(\".select2-results__options .select2-results__option[role=treeitem]:contains('{$value}')\")[0].click()");
+    $field = \str_replace('\\', '\\\\', $field);
+    $this->script("jQuery(\"$field\").val((function () { return jQuery(\"$field option:contains('$value')\").val(); })()).trigger('change')");
 
     return $this;
 });


### PR DESCRIPTION
When options are grouped in `optgroup`s and there's no search field, the script would choose the first option in a group. This update fixes this issue.